### PR TITLE
Create table of speed-up automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ We used the following models for the comparison:
 
 ## How to run the benchmarks locally
 
-To do this you can run the `runall.sh` file with `bash runall.sh`. It is easier to run the file with a Linux OS, but you can emulate the same behaviour on other systems. The requirements to do so are a Bash shell, to have Julia, Python, Java and Netlogo installed making available to use the commands `julia`, `python`, `java` and `javac` from the shell and to have the GNU Parallel tool available. Finally you need to move the folder where NetLogo is installed inside the folder where the Netlogo benchmarks reside. 
+To do this you can run the `runall.sh` file with `bash runall.sh`. It is easier to run the file with a Linux OS, but you can emulate the same behaviour on other systems. The requirements to do so are:
+
+- a Bash shell
+- To install the tested frameworks (except from Mason which is already provided)
+- To make the commands `julia`, `python`, `java` and `javac` available from the shell and to have the GNU Parallel tool available. 
+- Move the folder where NetLogo is installed inside the folder where the Netlogo benchmarks reside. 
 
 ## Contributions from other Frameworks
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ We used the following models for the comparison:
 
 To do this you can run the `runall.sh` file with `bash runall.sh`. It is easier to run the file with a Linux OS, but you can emulate the same behaviour on other systems. The requirements to do so are:
 
-- a Bash shell
-- To install the tested frameworks (except from Mason which is already provided)
-- To make the commands `julia`, `python`, `java` and `javac` available from the shell and to have the GNU Parallel tool available. 
+- To run the file on a bash shell;
+- To install the tested frameworks (except from Mason which is already provided);
+- To make the commands `julia`, `python`, `java` and `javac` available from the shell and to have the GNU Parallel tool available;
 - Move the folder where NetLogo is installed inside the folder where the Netlogo benchmarks reside. 
 
 ## Contributions from other Frameworks

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To do this you can run the `runall.sh` file with `bash runall.sh`. It is easier 
 - To run the file on a bash shell;
 - To install the tested frameworks (except for Mason which is already provided);
 - To make the commands `julia`, `python`, `java` and `javac` available from the shell and to have the GNU Parallel tool available;
-- Move the folder where NetLogo is installed inside the folder where the Netlogo benchmarks reside. 
+- To Move the folder where NetLogo is installed inside the folder where the Netlogo benchmarks reside and rename it as `netlogo`. 
 
 ## Contributions from other Frameworks
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We used the following models for the comparison:
 To do this you can run the `runall.sh` file with `bash runall.sh`. It is easier to run the file with a Linux OS, but you can emulate the same behaviour on other systems. The requirements to do so are:
 
 - To run the file on a bash shell;
-- To install the tested frameworks (except from Mason which is already provided);
+- To install the tested frameworks (except for Mason which is already provided);
 - To make the commands `julia`, `python`, `java` and `javac` available from the shell and to have the GNU Parallel tool available;
 - Move the folder where NetLogo is installed inside the folder where the Netlogo benchmarks reside. 
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ We used the following models for the comparison:
 - **Forest fire**, provides comparisons for cellular automata type ABMs (i.e. when agents do not move and every location in space contains exactly one agent). NOTE: The Agents.jl implementation of this model has been changed in v4.0 to be directly comparable to Mesa and NetLogo. As a consequence it no longer follows the [original rule-set](https://en.wikipedia.org/wiki/Forest-fire_model).
 - **Schelling's-segregation-model**, an additional `GridSpace` model to compare with MASON. Simpler rules than Wolf Sheep Grass.
 
+## How to run the benchmarks locally
+
+To do this you can run the `runall.sh` file with `bash runall.sh`. It is easier to run the file with a Linux OS, but you can emulate the same behaviour on other systems. The requirements to do so are a Bash shell, to have Julia, Python, Java and Netlogo installed making available to use the commands `julia`, `python`, `java` and `javac` from the shell and to have the GNU Parallel tool available. Finally you need to move the folder where NetLogo is installed inside the folder where the Netlogo benchmarks reside. 
+
 ## Contributions from other Frameworks
 
 We welcome improvements from other framework contributors, either with new code that beats the implementation provided here with updated improvements from your framework's development process.
@@ -18,3 +22,4 @@ We welcome improvements from other framework contributors, either with new code 
 Frameworks not included in the comparison are invited to provide code for the above, standardised comparison models.
 
 All are welcome to suggest better 'standard candle' models to test framework capability.
+

--- a/create_benchmark_table.jl
+++ b/create_benchmark_table.jl
@@ -1,0 +1,35 @@
+using PrettyTables
+
+frameworks = ["Agents.jl", "Mason", "Mesa", "NetLogo"]
+models = ["WolfSheep", "Flocking", "Schelling", "ForestFire"]
+
+frameworks_times = Dict(m => Dict(f => 0.0 for f in frameworks) for m in models)
+		  
+open("benchmark_results.txt", "r") do f
+    for line in readlines(f)
+        s_line = split(line)
+        !in(s_line[1], frameworks) && continue
+        frameworks_times[String(s_line[2])][String(s_line[1])] = parse(Float64, s_line[4])
+    end
+end
+
+frameworks_comparison = Dict(m => Dict(f => 0.0 for f in frameworks) for m in models)
+for m in models
+    for f in frameworks
+        if f == "Agents.jl"
+            frameworks_comparison[m][f] = 1
+        else
+            if frameworks_times[m][f] == 0.0
+                continue
+            else
+                v = round(frameworks_times[m][f]/frameworks_times[m]["Agents.jl"], digits=1)
+                frameworks_comparison[m][f] = v
+            end
+        end
+    end
+end
+
+columns = ["Model/Framework", "Agents 5.12.0", "MASON 21.0", "Mesa 1.2.0", "Netlogo 6.4"]
+results = mapreduce(permutedims, vcat, [vcat([m], [ifelse(frameworks_comparison[m][f] != 0, frameworks_comparison[m][f], ".") for f in frameworks]) for m in models])
+conf = set_pt_conf(tf = tf_markdown, alignment = :c)
+table = pretty_table_with_conf(conf, results; header = columns)

--- a/create_benchmark_table.jl
+++ b/create_benchmark_table.jl
@@ -19,12 +19,9 @@ for m in models
         if f == "Agents.jl"
             frameworks_comparison[m][f] = 1
         else
-            if frameworks_times[m][f] == 0.0
-                continue
-            else
-                v = round(frameworks_times[m][f]/frameworks_times[m]["Agents.jl"], digits=1)
-                frameworks_comparison[m][f] = v
-            end
+            frameworks_times[m][f] == 0.0 && continue
+            v = round(frameworks_times[m][f]/frameworks_times[m]["Agents.jl"], digits=1)
+            frameworks_comparison[m][f] = v
         end
     end
 end

--- a/runall.sh
+++ b/runall.sh
@@ -30,3 +30,5 @@ echo "NetLogo Schelling (ms): "$ws
 
 ws=$(parallel -j1 ::: $(printf 'NetLogo/ForestFire/benchmark_forestfire.sh %.0s' {1..100}) | sort | head -n1)
 echo "NetLogo ForestFire (ms): "$ws) | tee benchmark_results.txt
+
+julia create_benchmark_table.jl


### PR DESCRIPTION
I created a little script which makes it possible to create the table of speed-up automatically, I don't know if this is usuful to run benchmarks on CI, but I think that anyway it's useful to run the benchmarks locally. 

Running it, this is the table with all latest versions of all frameworks produced:

```
| Model/Framework | Agents 5.12.0 | MASON 21.0 | Mesa 1.2.0 | Netlogo 6.4 |
|-----------------|---------------|------------|------------|-------------|
|    WolfSheep    |      1.0      |     .      |    50.2    |    28.2     |
|    Flocking     |      1.0      |    9.0     |   129.8    |    25.5     |
|    Schelling    |      1.0      |   195.9    |   209.4    |    166.4    |
|   ForestFire    |      1.0      |     .      |   303.7    |    222.2    |
```
we can probably update the table in the docs with these new values!

What do you think about this @Datseris ? Looking at the source code in https://raw.githubusercontent.com/JuliaDynamics/Agents.jl/main/docs/src/comparison.md this table is still a bit different, probably we could try to calculate the LOC automatically (removing the docstrings from the files by hand first). Also I'd like to ask you, what about including the folder of NetLogo framework by default in the repo? It is big though (500mb), but this would make it possible to run the benchmark locally without any modification